### PR TITLE
CT-1547  remove done text drop shadow (Android)

### DIFF
--- a/android/src/main/res/layout/activity_photo_editor.xml
+++ b/android/src/main/res/layout/activity_photo_editor.xml
@@ -65,10 +65,6 @@
                 android:layout_marginStart="20dp"
                 android:layout_marginTop="10dp"
                 android:padding="10dp"
-                android:shadowColor="#FFFFFF"
-                android:shadowDx="0"
-                android:shadowDy="0"
-                android:shadowRadius="10"
                 android:text="@string/done"
                 android:textColor="#FFFFFF"
                 android:textSize="20sp"
@@ -85,7 +81,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="60dp"
                 android:layout_alignParentTop="true"
-                android:background="@drawable/fading_shadow" />
+                android:background="@android:color/transparent" />
 
             <RelativeLayout
                 android:id="@+id/top_parent_rl"
@@ -180,7 +176,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="100dp"
                 android:layout_alignParentBottom="true"
-                android:background="@drawable/below_shadow" />
+                android:background="@android:color/transparent" />
 
             <RelativeLayout
                 android:id="@+id/bottom_parent_rl"


### PR DESCRIPTION
This PR has a changes which removes backDrop shadow around "Done" text. 

After fix : 
<img width="385" alt="After" src="https://user-images.githubusercontent.com/71001045/123645450-fb922700-d843-11eb-8c91-b371d18db697.png">
